### PR TITLE
Change configuration name to match API parameter

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,7 +15,7 @@ module.exports = {
     agentNumber: process.env.AGENT_NUMBER,
 
     // An application SID is the way that a Twilio application is identified.
-    twimlAppSid: process.env.TWIML_APP_SID,
+    applicationSid: process.env.TWIML_APP_SID,
 
     // MongoDB connection string
     mongodbURI: process.env.MONGODB_URI,

--- a/token.js
+++ b/token.js
@@ -10,7 +10,7 @@ const generate = (identity) => {
 
     capability.addScope(new twilio.jwt.ClientCapability.IncomingClientScope(identity));
     capability.addScope(new twilio.jwt.ClientCapability.OutgoingClientScope({
-        applicationSid: config.twimlAppSid,
+        applicationSid: config.applicationSid,
         clientName: identity,
     }));
 


### PR DESCRIPTION
This change renames the configuration of the TwiML Application SID in the application
to more closely match how it is named in the API. I thought about changing the
environment variable too, but that would require more coordination with deployment
and I couldn't think of anything that was more descriptive.